### PR TITLE
Erro de lógica nos horários

### DIFF
--- a/javascript/core.js
+++ b/javascript/core.js
@@ -22,7 +22,7 @@ $(function(){
       var rodizioColor;
       var estaAqui = 'Você está aqui!';
 
-      if((d.getHours() >= 7 && d.getHours() <= 10) || (d.getHours() >= 17 && d.getHours() <= 20)){
+      if((d.getHours() >= 7 && d.getHours() < 10) || (d.getHours() >= 17 && d.getHours() < 20)){
         rodizioColor = colorRodizioOn;
       }else{
         rodizioColor = colorRodizioOff;


### PR DESCRIPTION
Se o horário do rodízio é das 7h as 10h e das 17h as 20h, então o comparativo da hora final não deve ser "menor ou igual", e sim apenas "menor".